### PR TITLE
Expose API base constant and auth helper

### DIFF
--- a/components/api.js
+++ b/components/api.js
@@ -1,7 +1,19 @@
 import axios from 'axios';
 
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'https://falcontrade-ai.onrender.com';
+
+export function authHeaders() {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('ft_token');
+    if (token) {
+      return { Authorization: `Bearer ${token}` };
+    }
+  }
+  return {};
+}
+
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE || 'https://falcontrade-ai.onrender.com',
+  baseURL: API_BASE,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -10,10 +22,7 @@ const api = axios.create({
 // Automatically include token if available
 api.interceptors.request.use((config) => {
   if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+    config.headers = { ...config.headers, ...authHeaders() };
   }
   return config;
 });


### PR DESCRIPTION
## Summary
- export `API_BASE` and `authHeaders` from API client module
- attach auth headers derived from `ft_token`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d7bccf2708325aa78822dc71be175