### PR TITLE
Use consistent localStorage key for auth token

### DIFF
--- a/components/api.js
+++ b/components/api.js
@@ -1,20 +1,23 @@
 import axios from 'axios';
 
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://falcontrade-ai.onrender.com';
+
+export function authHeaders() {
+  if (typeof window === 'undefined') return {};
+  const token = localStorage.getItem('ft_token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE || 'https://falcontrade-ai.onrender.com',
+  baseURL: API_BASE,
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
-// Automatically include token if available
 api.interceptors.request.use((config) => {
-  if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('ft_token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-  }
+  config.headers = { ...config.headers, ...authHeaders() };
   return config;
 });
 

--- a/components/api.js
+++ b/components/api.js
@@ -10,7 +10,7 @@ const api = axios.create({
 // Automatically include token if available
 api.interceptors.request.use((config) => {
   if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('ft_token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }


### PR DESCRIPTION
## Summary
- standardize on `ft_token` for auth token storage
- ensure API interceptor reads the `ft_token` key

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Attempted import error: 'API_BASE' is not exported from '../components/api')*

------
https://chatgpt.com/codex/tasks/task_e_689d7bce40148325a1cd6d9530c74ce6