### PR TITLE
Add auth token check for navigation

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,6 +1,16 @@
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 
 export default function Layout({ children }) {
+  const [hasToken, setHasToken] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('ft_token')
+      setHasToken(!!token)
+    }
+  }, [])
+
   const logout = () => {
     if (typeof window !== 'undefined') {
       localStorage.removeItem('ft_token');
@@ -15,9 +25,17 @@ export default function Layout({ children }) {
         <Link className="btn" href="/rfq/new">Post Need</Link>
         <Link className="btn" href="/offer/new">Post Offer</Link>
         <div style={{flex:1}} />
-        <Link className="btn" href="/login">Sign in</Link>
-        <Link className="btn btn-primary" href="/signup">Sign up</Link>
-        <button className="btn" onClick={logout}>Sign out</button>
+        {hasToken ? (
+          <>
+            {/* TODO: Add role-based links such as Admin here when available */}
+            <button className="btn" onClick={logout}>Sign out</button>
+          </>
+        ) : (
+          <>
+            <Link className="btn" href="/login">Sign in</Link>
+            <Link className="btn btn-primary" href="/signup">Sign up</Link>
+          </>
+        )}
       </nav>
       <div className="container">{children}</div>
     </>


### PR DESCRIPTION
## Summary
- Detect `ft_token` in `Layout` to switch nav links based on authentication state
- Show sign out when logged in and hide sign in/up links
- Add placeholder for future role-based links (e.g., Admin)

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d7bcf80ec8325a04dd1482a4ead05