### PR TITLE
Use listings endpoint for submissions and redirect to market

### DIFF
--- a/pages/offer/new.js
+++ b/pages/offer/new.js
@@ -9,8 +9,8 @@ export default function NewOffer() {
 
   const submit = async (e) => {
     e.preventDefault();
-    await api.post('/offers', { ...form, details });
-    router.push('/dashboard');
+    await api.post('/listings', { type: 'OFFER', ...form, details });
+    router.push('/market');
   };
 
   return (

--- a/pages/rfq/new.js
+++ b/pages/rfq/new.js
@@ -9,8 +9,8 @@ export default function NewRFQ() {
 
   const submit = async (e) => {
     e.preventDefault();
-    await api.post('/rfqs', { ...form, details });
-    router.push('/dashboard');
+    await api.post('/listings', { type: 'RFQ', ...form, details });
+    router.push('/market');
   };
 
   return (


### PR DESCRIPTION
## Summary
- Post new offers and RFQs to `/listings` with listing type
- Send users to the market page once a listing is created

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d7bd0d25083259f34eb100d0ed49b