### PR TITLE
Add admin dashboard scaffolding with role checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/pages/admin/alerts.js
+++ b/pages/admin/alerts.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function AdminAlerts() {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const role = localStorage.getItem('role')
+      if (role !== 'admin') {
+        router.replace('/')
+      }
+    }
+  }, [router])
+
+  return (
+    <div>
+      <h1>Alerts</h1>
+      <p>Stub page for managing alerts.</p>
+    </div>
+  )
+}

--- a/pages/admin/commodities.js
+++ b/pages/admin/commodities.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function AdminCommodities() {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const role = localStorage.getItem('role')
+      if (role !== 'admin') {
+        router.replace('/')
+      }
+    }
+  }, [router])
+
+  return (
+    <div>
+      <h1>Commodities</h1>
+      <p>Stub page for managing commodities.</p>
+    </div>
+  )
+}

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function AdminDashboard() {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const role = localStorage.getItem('role')
+      if (role !== 'admin') {
+        router.replace('/')
+      }
+    }
+  }, [router])
+
+  return (
+    <div>
+      <h1>Admin Dashboard</h1>
+      <p>Welcome to the admin dashboard.</p>
+    </div>
+  )
+}

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+
+export default function AdminUsers() {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const role = localStorage.getItem('role')
+      if (role !== 'admin') {
+        router.replace('/')
+      }
+    }
+  }, [router])
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <p>Stub page for managing users.</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- scaffold admin dashboard and management pages for users, commodities, and alerts
- add client-side role check redirecting non-admins to home
- ignore build artifacts and dependencies in git

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Attempted import error: 'API_BASE' is not exported)*

------
https://chatgpt.com/codex/tasks/task_e_689d7bd2bf7c83258a6052610d2fde89