### PR TITLE
Add static pages and footer navigation

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -20,6 +20,12 @@ export default function Layout({ children }) {
         <button className="btn" onClick={logout}>Sign out</button>
       </nav>
       <div className="container">{children}</div>
+      <footer className="footer" style={{marginTop:40, textAlign:'center'}}>
+        <Link className="btn" href="/about">About</Link>
+        <Link className="btn" href="/pricing">Pricing</Link>
+        <Link className="btn" href="/contact">Contact</Link>
+        <Link className="btn" href="/faq">FAQ</Link>
+      </footer>
     </>
   )
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    <div className="card">
+      <h1>About FalconTrade</h1>
+      <p>FalconTrade connects buyers and sellers across niche B2B markets.</p>
+    </div>
+  )
+}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+export default function Contact() {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+  const [file, setFile] = useState(null)
+
+  const submit = (e) => {
+    e.preventDefault()
+    alert('Message sent!')
+  }
+
+  return (
+    <div className="card" style={{maxWidth:600, margin:'20px auto'}}>
+      <h1>Contact Us</h1>
+      <form onSubmit={submit} className="space-y-2">
+        <input className="input" type="text" placeholder="Name" value={name} onChange={e=>setName(e.target.value)} required />
+        <input className="input" type="email" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required />
+        <textarea className="input" placeholder="Message" value={message} onChange={e=>setMessage(e.target.value)} required />
+        <input className="input" type="file" onChange={e=>setFile(e.target.files[0])} />
+        <button className="btn">Send</button>
+      </form>
+    </div>
+  )
+}

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -1,0 +1,8 @@
+export default function FAQ() {
+  return (
+    <div className="card">
+      <h1>FAQ</h1>
+      <p>Frequently asked questions will appear here.</p>
+    </div>
+  )
+}

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -1,0 +1,8 @@
+export default function Pricing() {
+  return (
+    <div className="card">
+      <h1>Pricing</h1>
+      <p>Pricing details will be available soon. Stay tuned!</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add placeholder About, Pricing, Contact, and FAQ pages
- Include contact form with document upload
- Add footer links to new pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d7bd85868832594f89f0327c306b0