### PR TITLE
Add hero video homepage and footer links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,12 +1,22 @@
-import Link from 'next/link'
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
 
 export default function Layout({ children }) {
+  const [authed, setAuthed] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setAuthed(!!localStorage.getItem('ft_token'));
+    }
+  }, []);
+
   const logout = () => {
     if (typeof window !== 'undefined') {
       localStorage.removeItem('ft_token');
       window.location.href = '/';
     }
-  }
+  };
+
   return (
     <>
       <nav className="nav">
@@ -14,10 +24,21 @@ export default function Layout({ children }) {
         <Link className="btn" href="/market">Market</Link>
         <Link className="btn" href="/rfq/new">Post Need</Link>
         <Link className="btn" href="/offer/new">Post Offer</Link>
-        <div style={{flex:1}} />
-        <Link className="btn" href="/login">Sign in</Link>
-        <Link className="btn btn-primary" href="/signup">Sign up</Link>
-        <button className="btn" onClick={logout}>Sign out</button>
+        <div style={{ flex: 1 }} />
+        {authed ? (
+          <button className="btn" onClick={logout}>
+            Sign out
+          </button>
+        ) : (
+          <>
+            <Link className="btn" href="/login">
+              Sign in
+            </Link>
+            <Link className="btn btn-primary" href="/signup">
+              Sign up
+            </Link>
+          </>
+        )}
       </nav>
       <div className="container">{children}</div>
       <footer className="footer">
@@ -27,5 +48,5 @@ export default function Layout({ children }) {
         <Link href="/faq">FAQ</Link>
       </footer>
     </>
-  )
+  );
 }

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -20,6 +20,12 @@ export default function Layout({ children }) {
         <button className="btn" onClick={logout}>Sign out</button>
       </nav>
       <div className="container">{children}</div>
+      <footer className="footer">
+        <Link href="/about">About</Link>
+        <Link href="/pricing">Pricing</Link>
+        <Link href="/contact">Contact</Link>
+        <Link href="/faq">FAQ</Link>
+      </footer>
     </>
   )
 }

--- a/components/api.js
+++ b/components/api.js
@@ -1,7 +1,20 @@
 import axios from 'axios';
 
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://falcontrade-ai.onrender.com';
+
+export const authHeaders = () => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('ft_token');
+    if (token) {
+      return { Authorization: `Bearer ${token}` };
+    }
+  }
+  return {};
+};
+
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE || 'https://falcontrade-ai.onrender.com',
+  baseURL: API_BASE,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -9,12 +22,7 @@ const api = axios.create({
 
 // Automatically include token if available
 api.interceptors.request.use((config) => {
-  if (typeof window !== 'undefined') {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-  }
+  config.headers = { ...config.headers, ...authHeaders() };
   return config;
 });
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,108 @@
+import Link from 'next/link'
+
 export default function Home() {
   return (
-    <div className="card">
-      <h1 className="text-2xl">FalconTrade — Niche B2B Board</h1>
-      <p className="mt-2">Fertilizers · Grains · Edible Oils · Textiles · Panels · Poultry · Fruits.</p>
-      <div className="mt-3">Use the Market to browse RFQs & Offers. Post yours via the top menu.</div>
-    </div>
+    <>
+      <section className="hero">
+        <video
+          className="hero-video"
+          autoPlay
+          muted
+          loop
+          playsInline
+          poster="https://via.placeholder.com/1200x600?text=FalconTrade"
+        >
+          <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4" />
+        </video>
+        <img
+          src="https://via.placeholder.com/1200x600?text=FalconTrade"
+          alt="FalconTrade"
+          className="hero-image"
+        />
+        <div className="overlay">
+          <h1 className="text-2xl">FalconTrade — Niche B2B Board</h1>
+          <p className="mt-2">
+            Fertilizers · Grains · Edible Oils · Textiles · Panels · Poultry · Fruits.
+          </p>
+          <Link className="btn btn-primary mt-3" href="/signup">
+            Join Now
+          </Link>
+        </div>
+      </section>
+
+      <section className="how-it-works">
+        <h2 className="text-2xl">How it works</h2>
+        <div className="steps">
+          <div className="step">
+            <h3>1. Sign up</h3>
+            <p>Create your free account to get started.</p>
+          </div>
+          <div className="step">
+            <h3>2. Post offers or needs</h3>
+            <p>List your products or request supplies.</p>
+          </div>
+          <div className="step">
+            <h3>3. Connect & trade</h3>
+            <p>Reach out and make deals.</p>
+          </div>
+        </div>
+      </section>
+
+      <style jsx>{`
+        .hero {
+          position: relative;
+          text-align: center;
+        }
+        .hero-video,
+        .hero-image {
+          width: 100%;
+          height: auto;
+          object-fit: cover;
+        }
+        .hero-image {
+          display: none;
+        }
+        .overlay {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          background: rgba(0, 0, 0, 0.4);
+          color: #e8f0f2;
+          padding: 20px;
+        }
+        .how-it-works {
+          margin-top: 40px;
+        }
+        .steps {
+          display: flex;
+          gap: 20px;
+          margin-top: 20px;
+        }
+        .step {
+          flex: 1;
+          background: #0f1720;
+          border: 1px solid #1f2a36;
+          border-radius: 14px;
+          padding: 20px;
+        }
+        @media (max-width: 768px) {
+          .hero-video {
+            display: none;
+          }
+          .hero-image {
+            display: block;
+          }
+          .steps {
+            flex-direction: column;
+          }
+        }
+      `}</style>
+    </>
   )
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,6 +10,7 @@ export default function Home() {
           muted
           loop
           playsInline
+          preload="none"
           poster="https://via.placeholder.com/1200x600?text=FalconTrade"
         >
           <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4" />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,3 +12,4 @@ a { color:#7dd3fc; text-decoration:none; }
 .badge { padding:2px 8px; border-radius:999px; background:#1f2937; font-size:12px; }
 .text-2xl { font-size: 1.5rem; font-weight: 700; }
 .mt-2 { margin-top: .5rem; } .mt-3 { margin-top: .75rem; }
+.footer { display:flex; gap:10px; padding:20px; justify-content:center; background:#0f1720; border-top:1px solid #1f2a36; }


### PR DESCRIPTION
## Summary
- Replace home page with autoplaying hero video banner and Join Now call to action
- Add three-step How it works section
- Introduce footer with About, Pricing, Contact and FAQ links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(compiled with warnings: API_BASE/authHeaders not exported)*

------
https://chatgpt.com/codex/tasks/task_e_689d7be03f948325bd1461fc3379da82