### PR TITLE
Add Stripe checkout and subscription gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+

--- a/components/withSubscription.js
+++ b/components/withSubscription.js
@@ -1,0 +1,19 @@
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
+export default function withSubscription(Component) {
+  return function WrappedComponent(props) {
+    const router = useRouter()
+
+    useEffect(() => {
+      if (typeof window !== 'undefined') {
+        const subscribed = localStorage.getItem('subscribed')
+        if (!subscribed) {
+          router.replace('/pricing')
+        }
+      }
+    }, [router])
+
+    return <Component {...props} />
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "falcontrade-frontend-v4",
       "dependencies": {
+        "@stripe/stripe-js": "^7.8.0",
         "axios": "^1.11.0",
         "next": "14.2.5",
         "react": "18.2.0",
@@ -150,6 +151,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.8.0.tgz",
+      "integrity": "sha512-DNXRfYUgkZlrniQORbA/wH8CdFRhiBSE0R56gYU0V5vvpJ9WZwvGrz9tBAZmfq2aTgw6SK7mNpmTizGzLWVezw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@swc/counter": {
@@ -710,6 +720,11 @@
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz",
       "integrity": "sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==",
       "optional": true
+    },
+    "@stripe/stripe-js": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.8.0.tgz",
+      "integrity": "sha512-DNXRfYUgkZlrniQORbA/wH8CdFRhiBSE0R56gYU0V5vvpJ9WZwvGrz9tBAZmfq2aTgw6SK7mNpmTizGzLWVezw=="
     },
     "@swc/counter": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@stripe/stripe-js": "^7.8.0",
     "axios": "^1.11.0",
     "next": "14.2.5",
     "react": "18.2.0",

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,0 +1,12 @@
+import withSubscription from '../components/withSubscription'
+
+function Admin() {
+  return (
+    <div className="card">
+      <h2 className="text-xl">Admin</h2>
+      <p>Admin area.</p>
+    </div>
+  )
+}
+
+export default withSubscription(Admin)

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,12 @@
+import withSubscription from '../components/withSubscription'
+
+function Dashboard() {
+  return (
+    <div className="card">
+      <h2 className="text-xl">Dashboard</h2>
+      <p>Welcome to your dashboard.</p>
+    </div>
+  )
+}
+
+export default withSubscription(Dashboard)

--- a/pages/market.js
+++ b/pages/market.js
@@ -1,7 +1,8 @@
+import withSubscription from '../components/withSubscription'
 import { useEffect, useState } from 'react'
 import { API_BASE } from '../components/api'
 
-export default function Market() {
+function Market() {
   const [items, setItems] = useState([])
   const [type, setType] = useState('')
   const [category, setCategory] = useState('')
@@ -57,3 +58,5 @@ export default function Market() {
     </div>
   )
 }
+
+export default withSubscription(Market)

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -1,0 +1,34 @@
+import { loadStripe } from '@stripe/stripe-js'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_KEY || '')
+
+export default function Pricing() {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (router.query.success) {
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('subscribed', 'true')
+      }
+    }
+  }, [router.query.success])
+
+  const handleSubscribe = async () => {
+    const stripe = await stripePromise
+    await stripe?.redirectToCheckout({
+      lineItems: [{ price: process.env.NEXT_PUBLIC_STRIPE_PRICE_ID, quantity: 1 }],
+      mode: 'subscription',
+      successUrl: window.location.origin + '/pricing?success=true',
+      cancelUrl: window.location.origin + '/pricing',
+    })
+  }
+
+  return (
+    <div className="card">
+      <h2 className="text-xl">Pricing</h2>
+      <button className="btn" onClick={handleSubscribe}>Subscribe</button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- install Stripe.js and add pricing checkout page
- track subscription status after successful payment
- protect dashboard, market, and admin pages behind subscription check

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Attempted import error: 'API_BASE' is not exported from '../components/api')*

------
https://chatgpt.com/codex/tasks/task_e_689d7be262188325a84f9b73f9118d79