### PR TITLE
feat: expand signup and pricing pages

### DIFF
--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -27,9 +27,51 @@ export default function Pricing() {
   }
 
   return (
-    <div className="card">
-      <h2 className="text-xl">Pricing</h2>
-      <button className="btn" onClick={handleSubscribe}>Subscribe</button>
+    <div className="max-w-5xl mx-auto mt-10 px-4">
+      <h2 className="text-3xl font-bold text-center mb-8">Choose your plan</h2>
+      <div className="grid md:grid-cols-3 gap-6">
+        <div className="bg-card border border-border rounded-xl p-6 flex flex-col">
+          <h3 className="text-xl font-semibold mb-4">Starter</h3>
+          <p className="text-4xl font-bold mb-4">$0<span className="text-base font-normal">/mo</span></p>
+          <ul className="flex-1 space-y-2 mb-6">
+            <li>Browse marketplace</li>
+            <li>Read public reports</li>
+            <li>Email support</li>
+          </ul>
+          <button className="w-full px-3 py-2 rounded-lg border border-border bg-background cursor-not-allowed" disabled>
+            Current
+          </button>
+        </div>
+
+        <div className="bg-card border-2 border-accent rounded-xl p-6 flex flex-col">
+          <h3 className="text-xl font-semibold mb-4">Pro</h3>
+          <p className="text-4xl font-bold mb-4">$249<span className="text-base font-normal">/mo</span></p>
+          <ul className="flex-1 space-y-2 mb-6">
+            <li>Full dashboard access</li>
+            <li>Real-time prices & forecasts</li>
+            <li>1 user account</li>
+          </ul>
+          <button className="w-full px-3 py-2 rounded-lg border border-border bg-background hover:bg-accent transition" onClick={handleSubscribe}>
+            Subscribe
+          </button>
+        </div>
+
+        <div className="bg-card border border-border rounded-xl p-6 flex flex-col">
+          <h3 className="text-xl font-semibold mb-4">Enterprise</h3>
+          <p className="text-4xl font-bold mb-4">$599<span className="text-base font-normal">/mo</span></p>
+          <ul className="flex-1 space-y-2 mb-6">
+            <li>Everything in Pro</li>
+            <li>Up to 5 user accounts</li>
+            <li>Dedicated broker & support</li>
+          </ul>
+          <a
+            href="/contact"
+            className="w-full text-center px-3 py-2 rounded-lg border border-border bg-background hover:bg-accent transition"
+          >
+            Contact sales
+          </a>
+        </div>
+      </div>
     </div>
   )
 }

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -2,6 +2,10 @@ import { useState } from 'react'
 import { API_BASE } from '../components/api'
 
 export default function Signup() {
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [company, setCompany] = useState('')
+  const [address, setAddress] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [msg, setMsg] = useState(null)
@@ -12,21 +16,79 @@ export default function Signup() {
     const res = await fetch(`${API_BASE}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password })
+      body: JSON.stringify({
+        email,
+        password,
+        first_name: firstName,
+        last_name: lastName,
+        company,
+        address,
+      })
     })
     if (!res.ok) { setMsg('Signup failed'); return }
     setMsg('Signup success — now sign in.')
   }
 
   return (
-    <div className="bg-card border border-border rounded-xl p-4 shadow max-w-md mx-auto mt-5">
-      <h2 className="text-xl font-bold">Create account</h2>
-      <form onSubmit={submit} className="mt-3 space-y-3">
-        <input className="w-full p-2 border border-border rounded-lg bg-background" type="email" placeholder="Email" value={email} onChange={e=>setEmail(e.target.value)} required/>
-        <input className="w-full p-2 border border-border rounded-lg bg-background" type="password" placeholder="Password (min 6)" value={password} onChange={e=>setPassword(e.target.value)} minLength={6} required />
-        <button className="px-3 py-2 rounded-lg border border-border bg-background">Sign up</button>
+    <div className="bg-card border border-border rounded-xl p-4 shadow max-w-lg mx-auto mt-5">
+      <h2 className="text-2xl font-bold text-center">Create account</h2>
+      <form onSubmit={submit} className="mt-4 space-y-3">
+        <div className="flex space-x-3">
+          <input
+            className="w-1/2 p-2 border border-border rounded-lg bg-background"
+            type="text"
+            placeholder="First name"
+            value={firstName}
+            onChange={e => setFirstName(e.target.value)}
+            required
+          />
+          <input
+            className="w-1/2 p-2 border border-border rounded-lg bg-background"
+            type="text"
+            placeholder="Last name"
+            value={lastName}
+            onChange={e => setLastName(e.target.value)}
+            required
+          />
+        </div>
+        <input
+          className="w-full p-2 border border-border rounded-lg bg-background"
+          type="text"
+          placeholder="Company"
+          value={company}
+          onChange={e => setCompany(e.target.value)}
+          required
+        />
+        <input
+          className="w-full p-2 border border-border rounded-lg bg-background"
+          type="text"
+          placeholder="Address"
+          value={address}
+          onChange={e => setAddress(e.target.value)}
+          required
+        />
+        <input
+          className="w-full p-2 border border-border rounded-lg bg-background"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="w-full p-2 border border-border rounded-lg bg-background"
+          type="password"
+          placeholder="Password (min 6)"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          minLength={6}
+          required
+        />
+        <button className="w-full px-3 py-2 rounded-lg border border-border bg-background hover:bg-accent transition">
+          Sign up
+        </button>
       </form>
-      {msg && <div className="mt-2">{msg}</div>}
+      {msg && <div className="mt-2 text-center">{msg}</div>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- collect detailed company information during signup
- present tiered pricing options with $249 and $599 plans

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d7b2910988325a0bc88f7f7a34629