### PR TITLE
Use Card component for pricing tiers

### DIFF
--- a/components/ui/card.js
+++ b/components/ui/card.js
@@ -1,0 +1,7 @@
+export function Card({ className = '', children, ...props }) {
+  return (
+    <div className={`bg-card border border-border rounded-xl shadow-md ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -2,6 +2,7 @@
 import { loadStripe } from '@stripe/stripe-js'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
+import { Card } from '@/components/ui/card'
 
 // simple check icon for feature lists
 const CheckIcon = () => (
@@ -70,7 +71,7 @@ export default function Pricing() {
     <div className="max-w-5xl mx-auto mt-10 px-4">
       <h2 className="text-3xl font-bold text-center mb-8">Choose your plan</h2>
       <div className="grid md:grid-cols-3 gap-6">
-        <div className="bg-card border border-border rounded-xl p-6 flex flex-col shadow-md">
+        <Card className="p-6 flex flex-col">
           <h3 className="text-xl font-semibold mb-4">Starter</h3>
           <p className="text-4xl font-bold mb-4">$0<span className="text-base font-normal">/mo</span></p>
           <ul className="flex-1 space-y-2 mb-6">
@@ -110,9 +111,9 @@ export default function Pricing() {
           <button className="w-full px-3 py-2 rounded-lg border border-border bg-background cursor-not-allowed" disabled>
             Current
           </button>
-        </div>
+        </Card>
 
-        <div className="bg-card border-2 border-accent rounded-xl p-6 flex flex-col shadow-md">
+        <Card className="border-2 border-accent p-6 flex flex-col">
           <h3 className="text-xl font-semibold mb-4">Pro</h3>
           <p className="text-4xl font-bold mb-4">$249<span className="text-base font-normal">/mo</span></p>
           <ul className="flex-1 space-y-2 mb-6">
@@ -157,9 +158,9 @@ export default function Pricing() {
           >
             Subscribe
           </button>
-        </div>
+        </Card>
 
-        <div className="bg-card border border-border rounded-xl p-6 flex flex-col shadow-md">
+        <Card className="p-6 flex flex-col">
           <h3 className="text-xl font-semibold mb-4">Enterprise</h3>
           <p className="text-4xl font-bold mb-4">$599<span className="text-base font-normal">/mo</span></p>
           <ul className="flex-1 space-y-2 mb-6">
@@ -203,7 +204,7 @@ export default function Pricing() {
           >
             Contact sales
           </a>
-        </div>
+        </Card>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- replace legacy div-based pricing containers with reusable Card component
- add Card UI component

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d978935848325ba0909f75946a53e