### PR TITLE
Store user role and expose admin link

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -4,16 +4,19 @@ import Link from 'next/link';
 
 export default function Layout({ children }) {
   const [authed, setAuthed] = useState(false);
+  const [role, setRole] = useState(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       setAuthed(!!localStorage.getItem('ft_token'));
+      setRole(localStorage.getItem('ft_role'));
     }
   }, []);
 
   const logout = () => {
     if (typeof window !== 'undefined') {
       localStorage.removeItem('ft_token');
+      localStorage.removeItem('ft_role');
       window.location.href = '/';
     }
   };
@@ -25,6 +28,9 @@ export default function Layout({ children }) {
         <Link className="btn" href="/market">Market</Link>
         <Link className="btn" href="/rfq/new">Post Need</Link>
         <Link className="btn" href="/offer/new">Post Offer</Link>
+        {role === 'admin' && (
+          <Link className="btn" href="/admin">Admin</Link>
+        )}
         <div style={{ flex: 1 }} />
         {authed ? (
           <button className="btn" onClick={logout}>

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -6,7 +6,7 @@ export default function AdminDashboard() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const role = localStorage.getItem('role')
+      const role = localStorage.getItem('ft_role')
       if (role !== 'admin') {
         router.replace('/')
       }

--- a/pages/login.js
+++ b/pages/login.js
@@ -20,6 +20,7 @@ export default function Login() {
     if (!res.ok) { setMsg('Login failed'); return }
     const data = await res.json()
     localStorage.setItem('ft_token', data.access_token)
+    localStorage.setItem('ft_role', data.role)
     window.location.href = '/market'
   }
 


### PR DESCRIPTION
## Summary
- Save user role from login response to localStorage
- Display Admin navigation link when user role is admin and update logout to clear role
- Ensure admin dashboard checks stored role before rendering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d94535d488325aa37cae607bb0d70