### PR TITLE
Add admin CRUD scaffolding and navigation

### DIFF
--- a/pages/admin/alerts.js
+++ b/pages/admin/alerts.js
@@ -1,22 +1,75 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+import api from '@/components/api'
 
 export default function AdminAlerts() {
   const router = useRouter()
+  const [alerts, setAlerts] = useState([])
+  const [form, setForm] = useState({ message: '' })
+
+  const isAdmin = () => typeof window !== 'undefined' && localStorage.getItem('role') === 'admin'
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const role = localStorage.getItem('role')
-      if (role !== 'admin') {
-        router.replace('/')
-      }
+    if (isAdmin()) {
+      fetchAlerts()
+    } else if (typeof window !== 'undefined') {
+      router.replace('/')
     }
   }, [router])
 
+  const fetchAlerts = async () => {
+    if (!isAdmin()) return
+    const res = await api.get('/admin/alerts')
+    setAlerts(res.data || [])
+  }
+
+  const createAlert = async (e) => {
+    e.preventDefault()
+    if (!isAdmin()) return
+    await api.post('/admin/alerts', form)
+    setForm({ message: '' })
+    fetchAlerts()
+  }
+
+  const updateAlert = async (id, message) => {
+    if (!isAdmin()) return
+    await api.put(`/admin/alerts/${id}`, { message })
+    fetchAlerts()
+  }
+
+  const deleteAlert = async (id) => {
+    if (!isAdmin()) return
+    await api.delete(`/admin/alerts/${id}`)
+    fetchAlerts()
+  }
+
   return (
     <div>
-      <h1>Alerts</h1>
-      <p>Stub page for managing alerts.</p>
+      <h1 className="text-xl font-bold">Alerts</h1>
+      <form onSubmit={createAlert} className="mt-4 space-y-2">
+        <input
+          className="border p-2"
+          placeholder="Message"
+          value={form.message}
+          onChange={e => setForm({ message: e.target.value })}
+        />
+        <button className="px-3 py-1 border">Create</button>
+      </form>
+      <ul className="mt-4 space-y-2">
+        {alerts.map(alert => (
+          <li key={alert.id} className="flex space-x-2 items-center">
+            <input
+              className="border p-1 flex-1"
+              value={alert.message || ''}
+              onChange={e =>
+                setAlerts(alerts.map(a => a.id === alert.id ? { ...a, message: e.target.value } : a))
+              }
+            />
+            <button className="px-2 py-1 border" onClick={() => updateAlert(alert.id, alert.message)}>Update</button>
+            <button className="px-2 py-1 border" onClick={() => deleteAlert(alert.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/pages/admin/commodities.js
+++ b/pages/admin/commodities.js
@@ -1,22 +1,70 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+import api from '@/components/api'
 
 export default function AdminCommodities() {
   const router = useRouter()
+  const [commodities, setCommodities] = useState([])
+  const [form, setForm] = useState({ name: '' })
+
+  const isAdmin = () => typeof window !== 'undefined' && localStorage.getItem('role') === 'admin'
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const role = localStorage.getItem('role')
-      if (role !== 'admin') {
-        router.replace('/')
-      }
+    if (isAdmin()) {
+      fetchCommodities()
+    } else if (typeof window !== 'undefined') {
+      router.replace('/')
     }
   }, [router])
 
+  const fetchCommodities = async () => {
+    if (!isAdmin()) return
+    const res = await api.get('/admin/commodities')
+    setCommodities(res.data || [])
+  }
+
+  const createCommodity = async (e) => {
+    e.preventDefault()
+    if (!isAdmin()) return
+    await api.post('/admin/commodities', form)
+    setForm({ name: '' })
+    fetchCommodities()
+  }
+
+  const updateCommodity = async (id, name) => {
+    if (!isAdmin()) return
+    await api.put(`/admin/commodities/${id}`, { name })
+    fetchCommodities()
+  }
+
+  const deleteCommodity = async (id) => {
+    if (!isAdmin()) return
+    await api.delete(`/admin/commodities/${id}`)
+    fetchCommodities()
+  }
+
   return (
     <div>
-      <h1>Commodities</h1>
-      <p>Stub page for managing commodities.</p>
+      <h1 className="text-xl font-bold">Commodities</h1>
+      <form onSubmit={createCommodity} className="mt-4 space-y-2">
+        <input className="border p-2" placeholder="Name" value={form.name} onChange={e => setForm({ name: e.target.value })} />
+        <button className="px-3 py-1 border">Create</button>
+      </form>
+      <ul className="mt-4 space-y-2">
+        {commodities.map(item => (
+          <li key={item.id} className="flex space-x-2 items-center">
+            <input
+              className="border p-1 flex-1"
+              value={item.name || ''}
+              onChange={e =>
+                setCommodities(commodities.map(c => c.id === item.id ? { ...c, name: e.target.value } : c))
+              }
+            />
+            <button className="px-2 py-1 border" onClick={() => updateCommodity(item.id, item.name)}>Update</button>
+            <button className="px-2 py-1 border" onClick={() => deleteCommodity(item.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 
 export default function AdminDashboard() {
   const router = useRouter()
@@ -14,9 +15,18 @@ export default function AdminDashboard() {
   }, [router])
 
   return (
-    <div>
-      <h1>Admin Dashboard</h1>
-      <p>Welcome to the admin dashboard.</p>
+    <div className="flex">
+      <nav className="w-48 border-r pr-4">
+        <ul className="space-y-2">
+          <li><Link href="/admin/alerts">Alerts</Link></li>
+          <li><Link href="/admin/commodities">Commodities</Link></li>
+          <li><Link href="/admin/users">Users</Link></li>
+        </ul>
+      </nav>
+      <div className="flex-1 pl-4">
+        <h1 className="text-xl font-bold">Admin Dashboard</h1>
+        <p>Select a module from the sidebar.</p>
+      </div>
     </div>
   )
 }

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -1,22 +1,78 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+import api from '@/components/api'
 
 export default function AdminUsers() {
   const router = useRouter()
+  const [users, setUsers] = useState([])
+  const [form, setForm] = useState({ email: '', role: '' })
+
+  const isAdmin = () => typeof window !== 'undefined' && localStorage.getItem('role') === 'admin'
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const role = localStorage.getItem('role')
-      if (role !== 'admin') {
-        router.replace('/')
-      }
+    if (isAdmin()) {
+      fetchUsers()
+    } else if (typeof window !== 'undefined') {
+      router.replace('/')
     }
   }, [router])
 
+  const fetchUsers = async () => {
+    if (!isAdmin()) return
+    const res = await api.get('/admin/users')
+    setUsers(res.data || [])
+  }
+
+  const createUser = async (e) => {
+    e.preventDefault()
+    if (!isAdmin()) return
+    await api.post('/admin/users', form)
+    setForm({ email: '', role: '' })
+    fetchUsers()
+  }
+
+  const updateUser = async (id, payload) => {
+    if (!isAdmin()) return
+    await api.put(`/admin/users/${id}`, payload)
+    fetchUsers()
+  }
+
+  const deleteUser = async (id) => {
+    if (!isAdmin()) return
+    await api.delete(`/admin/users/${id}`)
+    fetchUsers()
+  }
+
   return (
     <div>
-      <h1>Users</h1>
-      <p>Stub page for managing users.</p>
+      <h1 className="text-xl font-bold">Users</h1>
+      <form onSubmit={createUser} className="mt-4 space-y-2">
+        <input className="border p-2" placeholder="Email" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+        <input className="border p-2" placeholder="Role" value={form.role} onChange={e => setForm({ ...form, role: e.target.value })} />
+        <button className="px-3 py-1 border">Create</button>
+      </form>
+      <ul className="mt-4 space-y-2">
+        {users.map(user => (
+          <li key={user.id} className="flex space-x-2 items-center">
+            <input
+              className="border p-1 flex-1"
+              value={user.email || ''}
+              onChange={e =>
+                setUsers(users.map(u => u.id === user.id ? { ...u, email: e.target.value } : u))
+              }
+            />
+            <input
+              className="border p-1 w-24"
+              value={user.role || ''}
+              onChange={e =>
+                setUsers(users.map(u => u.id === user.id ? { ...u, role: e.target.value } : u))
+              }
+            />
+            <button className="px-2 py-1 border" onClick={() => updateUser(user.id, { email: user.email, role: user.role })}>Update</button>
+            <button className="px-2 py-1 border" onClick={() => deleteUser(user.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Scaffold CRUD interfaces for alerts, commodities, and users admin pages using central API helper and role-checked requests
- Add sidebar navigation to switch between admin modules
- Enforce role checks before all admin API interactions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d9450158c8325bb9ad33484e83ed8